### PR TITLE
fix(tonlibjson-sys): fix support for macos in build.rs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,3 @@ linker = "clang"
 [profile.release]
 debug = true
 lto = true
-
-[build]
-target = "x86_64-unknown-linux-gnu"

--- a/tonlibjson-sys/build.rs
+++ b/tonlibjson-sys/build.rs
@@ -1,10 +1,10 @@
-use cmake::Config;
 use std::env;
+
+use cmake::Config;
 
 fn main() {
     let is_release = env::var("PROFILE").unwrap() == "release";
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let is_macos = target_os == "macos";
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
     let ton_dir = if cfg!(feature = "testnet") {
@@ -14,7 +14,7 @@ fn main() {
     };
     eprintln!("ton dir is {}", ton_dir);
     println!("cargo:rerun-if-changed={ton_dir}/CMakeLists.txt");
-    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build.rs");
 
     if target_os == "macos" {
         println!("cargo:rustc-link-lib=dylib=c++");
@@ -87,7 +87,7 @@ fn main() {
             );
     }
 
-    if is_macos {
+    if target_os == "macos" {
         cfg.cxxflag("-stdlib=libc++");
     } else if is_release {
         cfg.cxxflag("-flto")

--- a/tonlibjson-sys/build.rs
+++ b/tonlibjson-sys/build.rs
@@ -1,93 +1,118 @@
-use std::env;
 use cmake::Config;
+use std::env;
 
 fn main() {
     let is_release = env::var("PROFILE").unwrap() == "release";
-    let target = env::var("TARGET").unwrap();
-    let is_darwin = target == "x86_64-apple-darwin";
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let is_macos = target_os == "macos";
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
-    let openssl_dir = env::var("OPENSSL_ROOT_DIR")
-        .ok()
-        .map(|x| format!("{}/lib", x))
-        .or_else(
-            || pkg_config::probe_library("openssl")
-                .ok()
-                .map(|lib| lib.link_paths.first().unwrap().display().to_string())
-        ).unwrap();
-
-    let ton_dir = if cfg!(feature = "testnet") { "ton-testnet" } else { "ton" };
-    let build_tonlibjson = cfg!(feature = "tonlibjson");
-    let build_emulator = cfg!(feature = "tonemulator");
-
-    eprintln!("ton dir is {}", ton_dir);
-
-    if is_darwin {
-        println!("cargo:rustc-link-lib=dylib=c++");
+    let ton_dir = if cfg!(feature = "testnet") {
+        "ton-testnet"
     } else {
-        println!("cargo:rustc-link-lib=static=c++");
+        "ton"
+    };
+    eprintln!("ton dir is {}", ton_dir);
+    println!("cargo:rerun-if-changed={ton_dir}/CMakeLists.txt");
+    println!("cargo::rerun-if-changed=build.rs");
+
+    if target_os == "macos" {
+        println!("cargo:rustc-link-lib=dylib=c++");
+    } else if target_os == "linux" {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
     }
 
-    println!("cargo:rustc-link-search=native={}", openssl_dir);
+    let openssl_dir = env::var("OPENSSL_ROOT_DIR").unwrap_or_else(|_| {
+        pkg_config::probe_library("openssl")
+            .unwrap()
+            .link_paths
+            .first()
+            .unwrap()
+            .display()
+            .to_string()
+    });
+    println!("cargo:rustc-link-search=native={}/lib", openssl_dir);
     println!("cargo:rustc-link-lib=static=crypto");
     println!("cargo:rustc-link-lib=static=ssl");
 
+    let sodium_dir = pkg_config::probe_library("libsodium")
+        .unwrap()
+        .link_paths
+        .first()
+        .unwrap()
+        .to_owned();
+    println!("cargo:rustc-link-search=native={}", sodium_dir.display());
     println!("cargo:rustc-link-lib=static=sodium");
+
+    let secp256k1_dir = pkg_config::probe_library("libsecp256k1")
+        .unwrap()
+        .link_paths
+        .first()
+        .unwrap()
+        .to_owned();
+    println!("cargo:rustc-link-search=native={}", secp256k1_dir.display());
     println!("cargo:rustc-link-lib=static=secp256k1");
 
-    let target_arch = "x86-64";
+    if cfg!(feature = "tonlibjson") {
+        let mut cfg = Config::new(ton_dir);
+        cfg.uses_cxx11()
+            .configure_arg("-DTON_ONLY_TONLIB=ON")
+            .configure_arg("-DBUILD_SHARED_LIBS=FALSE")
+            .configure_arg("-DCMAKE_EXE_LINKER_FLAGS=-L/opt/homebrew/lib")
+            .define("TON_ONLY_TONLIB", "ON")
+            .define("CMAKE_C_COMPILER", "clang")
+            .define("CMAKE_CXX_COMPILER", "clang++")
+            .define("CMAKE_CXX_STANDARD", "14")
+            .define("BUILD_SHARED_LIBS", "OFF")
+            .define("PORTABLE", "ON")
+            .define("TON_ARCH", &target_arch)
+            .cxxflag("-std=c++14")
+            .cxxflag("-stdlib=libc++")
+            .build_target("tonlibjson")
+            .always_configure(true);
+        if is_release {
+            cfg.define("CMAKE_BUILD_TYPE", "Release");
+            if !is_macos {
+                cfg.cxxflag("-flto")
+                    .define("CMAKE_EXE_LINKER_FLAGS_INIT", "-fuse-ld=lld")
+                    .define("CMAKE_MODULE_LINKER_FLAGS_INIT", "-fuse-ld=lld")
+                    .define("CMAKE_SHARED_LINKER_FLAGS_INIT", "-fuse-ld=lld");
+            }
+        }
+        let dst = cfg.build();
 
-    if build_tonlibjson {
-        let dst= if !is_darwin && is_release {
-            Config::new(ton_dir)
-                .define("TON_ONLY_TONLIB", "ON")
-                .define("CMAKE_C_COMPILER", "clang")
-                .define("CMAKE_CXX_COMPILER", "clang++")
-                .define("CMAKE_CXX_STANDARD", "14")
-                .define("BUILD_SHARED_LIBS", "OFF")
-                .define("SODIUM_USE_STATIC_LIBS", "OFF")
-                .define("PORTABLE", "ON")
-                .define("TON_ARCH", target_arch)
-                .cxxflag("-std=c++14")
-                .cxxflag("-stdlib=libc++")
-                .cxxflag("-flto")
-                .define("CMAKE_EXE_LINKER_FLAGS_INIT", "-fuse-ld=lld")
-                .define("CMAKE_MODULE_LINKER_FLAGS_INIT", "-fuse-ld=lld")
-                .define("CMAKE_SHARED_LINKER_FLAGS_INIT", "-fuse-ld=lld")
-                .uses_cxx11()
-                .build_target("tonlibjson")
-                .build()
-        } else {
-            Config::new(ton_dir)
-                .uses_cxx11()
-                .define("TON_ONLY_TONLIB", "ON")
-                .define("CMAKE_C_COMPILER", "clang")
-                .define("CMAKE_CXX_COMPILER", "clang++")
-                .define("CMAKE_CXX_STANDARD", "14")
-                .define("BUILD_SHARED_LIBS", "OFF")
-                .define("SODIUM_USE_STATIC_LIBS", "OFF")
-                .define("PORTABLE", "ON")
-                .define("TON_ARCH", target_arch)
-                .cxxflag("-std=c++14")
-                .cxxflag("-stdlib=libc++")
-                .build_target("tonlibjson")
-                .build()
-        };
-
-        println!("cargo:rustc-link-search=native={}/build/third-party/blst", dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/build/third-party/blst",
+            dst.display()
+        );
         println!("cargo:rustc-link-lib=static=blst");
 
         for item in ["tdnet", "keys", "tdactor", "tl-utils", "tdutils"] {
-            println!("cargo:rustc-link-search=native={}/build/{}", dst.display(), item);
+            println!(
+                "cargo:rustc-link-search=native={}/build/{}",
+                dst.display(),
+                item
+            );
             println!("cargo:rustc-link-lib=static={}", item)
         }
+        println!("cargo:rustc-link-lib=static=tl-lite-utils");
 
-        println!("cargo:rustc-link-search=native={}/build/adnl", dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/build/adnl",
+            dst.display()
+        );
         println!("cargo:rustc-link-lib=static=adnllite");
 
-        println!("cargo:rustc-link-search=native={}/build/lite-client", dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/build/lite-client",
+            dst.display()
+        );
         println!("cargo:rustc-link-lib=static=lite-client-common");
 
-        println!("cargo:rustc-link-search=native={}/build/crypto", dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/build/crypto",
+            dst.display()
+        );
         println!("cargo:rustc-link-lib=static=ton_crypto");
         println!("cargo:rustc-link-lib=static=ton_crypto_core");
 
@@ -100,10 +125,16 @@ fn main() {
         println!("cargo:rustc-link-lib=static=tl_tonlib_api");
         println!("cargo:rustc-link-lib=static=tl_tonlib_api_json");
 
-        println!("cargo:rustc-link-search=native={}/build/tddb", dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/build/tddb",
+            dst.display()
+        );
         println!("cargo:rustc-link-lib=static=tddb_utils");
 
-        println!("cargo:rustc-link-search=native={}/build/third-party/crc32c", dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/build/third-party/crc32c",
+            dst.display()
+        );
         println!("cargo:rustc-link-lib=static=crc32c");
 
         println!("cargo:rustc-link-search=native={}/lib", dst.display());
@@ -112,61 +143,62 @@ fn main() {
         println!("cargo:rustc-link-lib=static=tdutils");
         println!("cargo:rustc-link-lib=static=tl-lite-utils");
 
-        println!("cargo:rustc-link-search=native={}/build/emulator", dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/build/emulator",
+            dst.display()
+        );
+        println!("cargo:rerun-if-changed={}/build/emulator", dst.display());
         println!("cargo:rustc-link-lib=static=emulator_static");
 
-        println!("cargo:rustc-link-search=native={}/build/tonlib", dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/build/tonlib",
+            dst.display()
+        );
+        println!("cargo:rerun-if-changed={}/build/tonlib", dst.display());
         println!("cargo:rustc-link-lib=static=tonlib");
         println!("cargo:rustc-link-lib=static=tonlibjson_private");
         println!("cargo:rustc-link-lib=static=tonlibjson");
     }
 
-    if build_emulator {
-        let dst = if !is_darwin && is_release {
-            Config::new(ton_dir)
-                .define("TON_ONLY_TONLIB", "ON")
-                .define("CMAKE_C_COMPILER", "clang")
-                .define("CMAKE_CXX_COMPILER", "clang++")
-                .define("CMAKE_CXX_STANDARD", "14")
-                .define("BUILD_SHARED_LIBS", "OFF")
-                .define("SODIUM_USE_STATIC_LIBS", "OFF")
-                .define("PORTABLE", "ON")
-                .define("TON_ARCH", target_arch)
-                .cxxflag("-std=c++14")
-                .cxxflag("-stdlib=libc++")
-                .cxxflag("-flto")
+    if cfg!(feature = "tonemulator") {
+        let mut cfg = Config::new(ton_dir);
+        cfg.uses_cxx11()
+            .define("TON_ONLY_TONLIB", "ON")
+            .define("CMAKE_C_COMPILER", "clang")
+            .define("CMAKE_CXX_COMPILER", "clang++")
+            .define("CMAKE_CXX_STANDARD", "14")
+            .define("BUILD_SHARED_LIBS", "OFF")
+            .define("PORTABLE", "ON")
+            .define("TON_ARCH", target_arch)
+            .cxxflag("-std=c++14")
+            .cxxflag("-stdlib=libc++")
+            .build_target("emulator");
+        if !is_macos && is_release {
+            cfg.cxxflag("-flto")
                 .define("CMAKE_EXE_LINKER_FLAGS_INIT", "-fuse-ld=lld")
                 .define("CMAKE_MODULE_LINKER_FLAGS_INIT", "-fuse-ld=lld")
-                .define("CMAKE_SHARED_LINKER_FLAGS_INIT", "-fuse-ld=lld")
-                .uses_cxx11()
-                .build_target("emulator")
-                .build()
-        } else {
-            Config::new(ton_dir)
-                .uses_cxx11()
-                .define("TON_ONLY_TONLIB", "ON")
-                .define("CMAKE_C_COMPILER", "clang")
-                .define("CMAKE_CXX_COMPILER", "clang++")
-                .define("CMAKE_CXX_STANDARD", "14")
-                .define("BUILD_SHARED_LIBS", "OFF")
-                .define("SODIUM_USE_STATIC_LIBS", "OFF")
-                .define("PORTABLE", "ON")
-                .define("TON_ARCH", target_arch)
-                .cxxflag("-std=c++14")
-                .cxxflag("-stdlib=libc++")
-                .build_target("emulator")
-                .build()
-        };
+                .define("CMAKE_SHARED_LINKER_FLAGS_INIT", "-fuse-ld=lld");
+        }
+        let dst = cfg.build();
 
-        println!("cargo:rustc-link-search=native={}/build/third-party/blst", dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/build/third-party/blst",
+            dst.display()
+        );
         println!("cargo:rustc-link-lib=static=blst");
 
-        println!("cargo:rustc-link-search=native={}/build/crypto", dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/build/crypto",
+            dst.display()
+        );
         println!("cargo:rustc-link-lib=static=ton_crypto");
         println!("cargo:rustc-link-lib=static=ton_block");
         println!("cargo:rustc-link-lib=static=smc-envelope");
 
-        println!("cargo:rustc-link-search=native={}/build/emulator", dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/build/emulator",
+            dst.display()
+        );
         println!("cargo:rustc-link-lib=static=emulator_static");
         println!("cargo:rustc-link-lib=static=emulator");
     }

--- a/tonlibjson-sys/build.rs
+++ b/tonlibjson-sys/build.rs
@@ -179,25 +179,7 @@ fn main() {
     }
 
     if cfg!(feature = "tonemulator") {
-        let mut cfg = Config::new(ton_dir);
-        cfg.uses_cxx11()
-            .define("TON_ONLY_TONLIB", "ON")
-            .define("CMAKE_C_COMPILER", "clang")
-            .define("CMAKE_CXX_COMPILER", "clang++")
-            .define("CMAKE_CXX_STANDARD", "14")
-            .define("BUILD_SHARED_LIBS", "OFF")
-            .define("PORTABLE", "ON")
-            .define("TON_ARCH", target_arch)
-            .cxxflag("-std=c++14")
-            .cxxflag("-stdlib=libc++")
-            .build_target("emulator");
-        if !is_macos && is_release {
-            cfg.cxxflag("-flto")
-                .define("CMAKE_EXE_LINKER_FLAGS_INIT", "-fuse-ld=lld")
-                .define("CMAKE_MODULE_LINKER_FLAGS_INIT", "-fuse-ld=lld")
-                .define("CMAKE_SHARED_LINKER_FLAGS_INIT", "-fuse-ld=lld");
-        }
-        let dst = cfg.build();
+        let dst = cfg.build_target("emulator").build();
 
         println!(
             "cargo:rustc-link-search=native={}/build/third-party/blst",

--- a/tonlibjson-sys/build.rs
+++ b/tonlibjson-sys/build.rs
@@ -5,7 +5,6 @@ use cmake::Config;
 fn main() {
     let is_release = env::var("PROFILE").unwrap() == "release";
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
     let ton_dir = if cfg!(feature = "testnet") {
         "ton-testnet"
@@ -59,7 +58,6 @@ fn main() {
         .define("CMAKE_CXX_COMPILER", "clang++")
         .define("PORTABLE", "ON")
         .define("BUILD_SHARED_LIBS", "OFF")
-        .define("TON_ARCH", &target_arch)
         .always_configure(true)
         .very_verbose(false);
 

--- a/tonlibjson-sys/build.rs
+++ b/tonlibjson-sys/build.rs
@@ -163,14 +163,12 @@ fn main() {
             "cargo:rustc-link-search=native={}/build/emulator",
             dst.display()
         );
-        println!("cargo:rerun-if-changed={}/build/emulator", dst.display());
         println!("cargo:rustc-link-lib=static=emulator_static");
 
         println!(
             "cargo:rustc-link-search=native={}/build/tonlib",
             dst.display()
         );
-        println!("cargo:rerun-if-changed={}/build/tonlib", dst.display());
         println!("cargo:rustc-link-lib=static=tonlib");
         println!("cargo:rustc-link-lib=static=tonlibjson_private");
         println!("cargo:rustc-link-lib=static=tonlibjson");


### PR DESCRIPTION
Hey Team, thank you for these bindings! ❤️


I tried to use `tonlibjson-client and encountered an issue:
```toml
[dependepcies]
tonlibjson-client = { git = "https://github.com/getgems-io/ton-grpc.git" }
```

It didn't compile successfully on my MacBook M1:
<details>

  <summary><code>cargo build</code> output</summary>

```sh
cargo build
    Updating git repository `https://github.com/getgems-io/ton-grpc.git`
   Compiling tonlibjson-sys v0.3.1 (https://github.com/getgems-io/ton-grpc.git#f257c0da)
   Compiling tl_parser v0.1.0 (https://github.com/getgems-io/ton-grpc.git#f257c0da)
   Compiling tonlibjson-client v0.17.2 (https://github.com/getgems-io/ton-grpc.git#f257c0da)
error: failed to run custom build command for `tonlibjson-sys v0.3.1 (https://github.com/getgems-io/ton-grpc.git#f257c0da)`

Caused by:
  process didn't exit successfully: `/dev/project/target/debug/build/tonlibjson-sys-1480e5ed93844183/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=OPENSSL_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=OPENSSL_STATIC
  cargo:rerun-if-env-changed=OPENSSL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=OPENSSL_STATIC
  cargo:rerun-if-env-changed=OPENSSL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rustc-link-search=native=/opt/homebrew/Cellar/openssl@3/3.3.0
  cargo:rustc-link-lib=ssl
  cargo:rustc-link-lib=crypto
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=OPENSSL_STATIC
  cargo:rerun-if-env-changed=OPENSSL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  cargo:rustc-link-lib=static=c++
  cargo:rustc-link-search=native=/opt/homebrew/Cellar/openssl@3/3.3.0
  cargo:rustc-link-lib=static=crypto
  cargo:rustc-link-lib=static=ssl
  cargo:rustc-link-lib=static=sodium
  cargo:rustc-link-lib=static=secp256k1
  CMAKE_TOOLCHAIN_FILE_aarch64-apple-darwin = None
  CMAKE_TOOLCHAIN_FILE_aarch64_apple_darwin = None
  HOST_CMAKE_TOOLCHAIN_FILE = None
  CMAKE_TOOLCHAIN_FILE = None
  CMAKE_GENERATOR_aarch64-apple-darwin = None
  CMAKE_GENERATOR_aarch64_apple_darwin = None
  HOST_CMAKE_GENERATOR = None
  CMAKE_GENERATOR = None
  CMAKE_PREFIX_PATH_aarch64-apple-darwin = None
  CMAKE_PREFIX_PATH_aarch64_apple_darwin = None
  HOST_CMAKE_PREFIX_PATH = None
  CMAKE_PREFIX_PATH = None
  CMAKE_aarch64-apple-darwin = None
  CMAKE_aarch64_apple_darwin = None
  HOST_CMAKE = None
  CMAKE = None
  running: cd "/dev/project/target/debug/build/tonlibjson-sys-84f116fed36e0b68/out/build" && CMAKE_PREFIX_PATH="" "cmake" "/root/.cargo/git/checkouts/ton-grpc-8931e6ba334d2bde/f257c0d/tonlibjson-sys/ton-testnet" "-DCMAKE_OSX_ARCHITECTURES=arm64" "-DTON_ONLY_TONLIB=ON" "-DCMAKE_C_COMPILER=clang" "-DCMAKE_CXX_COMPILER=clang++" "-DCMAKE_CXX_STANDARD=14" "-DBUILD_SHARED_LIBS=OFF" "-DSODIUM_USE_STATIC_LIBS=OFF" "-DPORTABLE=ON" "-DTON_ARCH=x86-64" "-DCMAKE_SYSTEM_NAME=Darwin" "-DCMAKE_SYSTEM_PROCESSOR=arm64" "-DCMAKE_INSTALL_PREFIX=/root/dev/project/target/debug/build/tonlibjson-sys-84f116fed36e0b68/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC --target=arm64-apple-darwin -mmacosx-version-min=10.11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" "-DCMAKE_CXX_FLAGS= -std=c++14 -stdlib=libc++ -ffunction-sections -fdata-sections -fPIC --target=arm64-apple-darwin -mmacosx-version-min=10.11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC --target=arm64-apple-darwin -mmacosx-version-min=10.11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" "-DCMAKE_ASM_COMPILER=/usr/bin/cc" "-DCMAKE_BUILD_TYPE=Debug"
  -- The C compiler identification is AppleClang 15.0.0.15000100
  -- The CXX compiler identification is AppleClang 15.0.0.15000100
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: /usr/bin/clang - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: /usr/bin/clang++ - skipped
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  -- Performing Test CRC32C_HAVE_SSE42
  -- Performing Test CRC32C_HAVE_SSE42 - Failed
  -- Performing Test ROCKSDB_HAVE_SSE42
  -- Performing Test ROCKSDB_HAVE_SSE42 - Failed
  -- Performing Test CRC32C_HAVE_NO_DEPRECATED
  -- Performing Test CRC32C_HAVE_NO_DEPRECATED - Success
  -- Performing Test CRC32C_HAVE_NO_SIGN_COMPARE
  -- Performing Test CRC32C_HAVE_NO_SIGN_COMPARE - Success
  -- Performing Test CRC32C_HAVE_NO_UNUSED_PARAMETER
  -- Performing Test CRC32C_HAVE_NO_UNUSED_PARAMETER - Success
  -- Performing Test CRC32C_HAVE_NO_MISSING_FIELD_INITIALIZERS
  -- Performing Test CRC32C_HAVE_NO_MISSING_FIELD_INITIALIZERS - Success
  -- Performing Test HAVE_BUILTIN_PREFETCH
  -- Performing Test HAVE_BUILTIN_PREFETCH - Success
  -- Performing Test HAVE_MM_PREFETCH
  -- Performing Test HAVE_MM_PREFETCH - Failed
  -- Performing Test HAVE_ARM64_CRC32C
  -- Performing Test HAVE_ARM64_CRC32C - Success
  -- Performing Test HAVE_STRONG_GETAUXVAL
  -- Performing Test HAVE_STRONG_GETAUXVAL - Failed
  -- Performing Test HAVE_WEAK_GETAUXVAL
  -- Performing Test HAVE_WEAK_GETAUXVAL - Failed
  -- Could NOT find ccache
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
  -- Found Threads: TRUE  
  -- Found PkgConfig: /opt/homebrew/bin/pkg-config (found version "0.29.2") 
  -- Found ZLIB: /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/lib/libz.tbd (found version "1.2.12")  
  -- Performing Test COMPILER_OPT_ARCH_SUPPORTED
  -- Performing Test COMPILER_OPT_ARCH_SUPPORTED - Failed
  -- Performing Test HAVE_CXX_FLAG_WALL
  -- Performing Test HAVE_CXX_FLAG_WALL - Success
  -- Performing Test HAVE_CXX_FLAG_WEXTRA
  -- Performing Test HAVE_CXX_FLAG_WEXTRA - Success
  -- Performing Test HAVE_CXX_FLAG_WIMPLICIT_FALLTHROUGH_2
  -- Performing Test HAVE_CXX_FLAG_WIMPLICIT_FALLTHROUGH_2 - Failed
  -- Performing Test HAVE_CXX_FLAG_WPOINTER_ARITH
  -- Performing Test HAVE_CXX_FLAG_WPOINTER_ARITH - Success
  -- Performing Test HAVE_CXX_FLAG_WCAST_QUAL
  -- Performing Test HAVE_CXX_FLAG_WCAST_QUAL - Success
  -- Performing Test HAVE_CXX_FLAG_WSIGN_COMPARE
  -- Performing Test HAVE_CXX_FLAG_WSIGN_COMPARE - Success
  -- Performing Test HAVE_CXX_FLAG_WDUPLICATED_BRANCHES
  -- Performing Test HAVE_CXX_FLAG_WDUPLICATED_BRANCHES - Failed
  -- Performing Test HAVE_CXX_FLAG_WDUPLICATED_COND
  -- Performing Test HAVE_CXX_FLAG_WDUPLICATED_COND - Failed
  -- Performing Test HAVE_CXX_FLAG_WALLOC_ZERO
  -- Performing Test HAVE_CXX_FLAG_WALLOC_ZERO - Failed
  -- Performing Test HAVE_CXX_FLAG_WLOGICAL_OP
  -- Performing Test HAVE_CXX_FLAG_WLOGICAL_OP - Failed
  -- Performing Test HAVE_CXX_FLAG_WTAUTOLOGICAL_COMPARE
  -- Performing Test HAVE_CXX_FLAG_WTAUTOLOGICAL_COMPARE - Success
  -- Performing Test HAVE_CXX_FLAG_WVLA
  -- Performing Test HAVE_CXX_FLAG_WVLA - Success
  -- Performing Test HAVE_CXX_FLAG_WNON_VIRTUAL_DTOR
  -- Performing Test HAVE_CXX_FLAG_WNON_VIRTUAL_DTOR - Success
  -- Performing Test HAVE_CXX_FLAG_WUNUSED_PARAMETER
  -- Performing Test HAVE_CXX_FLAG_WUNUSED_PARAMETER - Success
  -- Performing Test HAVE_CXX_FLAG_WCONVERSION
  -- Performing Test HAVE_CXX_FLAG_WCONVERSION - Success
  -- Performing Test HAVE_CXX_FLAG_WSIGN_CONVERSION
  -- Performing Test HAVE_CXX_FLAG_WSIGN_CONVERSION - Success
  -- Performing Test HAVE_CXX_FLAG_QUNUSED_ARGUMENTS
  -- Performing Test HAVE_CXX_FLAG_QUNUSED_ARGUMENTS - Success
  -- Performing Test HAVE_CXX_FLAG_WUNUSED_PRIVATE_FIELD
  -- Performing Test HAVE_CXX_FLAG_WUNUSED_PRIVATE_FIELD - Success
  -- Performing Test HAVE_CXX_FLAG_WREDUNDANT_MOVE
  -- Performing Test HAVE_CXX_FLAG_WREDUNDANT_MOVE - Success
  -- Could NOT find LATEX (missing: LATEX_COMPILER) 
  -- Could NOT find LATEX (this is NOT an error)
  -- Found ZLIB: /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/lib/libz.tbd
  -- Found OpenSSL: /opt/homebrew/Cellar/openssl@3/3.3.0/lib/libcrypto.dylib (found version "3.3.0")  
  -- Checking for module 'liblz4'
  --   Found liblz4, version 1.9.4
  -- Found LZ4 lz4 /opt/homebrew/Cellar/lz4/1.9.4/include
  -- Performing Test GNU_READLINE_FOUND
  -- Performing Test GNU_READLINE_FOUND - Failed
  -- Could NOT find Readline (missing: READLINE_INCLUDE_DIR READLINE_LIBRARY) 
  -- Could NOT find Readline (this is NOT an error)
  -- Found Secp256k1: /opt/homebrew/lib/libsecp256k1.dylib
  -- Found Secp256k1: /opt/homebrew/include  
  -- Found Sodium: /opt/homebrew/Cellar/libsodium/1.0.19/lib/libsodium.dylib  
  -- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
  -- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
  -- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
  -- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
  -- Performing Test COMPILER_HAS_DEPRECATED_ATTR
  -- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
  -- Configuring done (4.9s)

  --- stderr
  ton dir is ton-testnet
  Add crc32c
  CMake Deprecation Warning at third-party/crc32c/CMakeLists.txt:5 (cmake_minimum_required):
    Compatibility with CMake < 3.5 will be removed from a future version of
    CMake.

    Update the VERSION argument <min> value or use a ...<max> suffix to tell
    CMake that the project does not need compatibility with older versions.


  Add ton
  CMake Error at crypto/CMakeLists.txt:378 (add_library):
    Cannot find source file:

      /root/.cargo/git/checkouts/ton-grpc-8931e6ba334d2bde/f257c0d/tonlibjson-sys/ton-testnet/crypto/block/block-auto.cpp

    Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm
    .ccm .cxxm .c++m .h .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90
    .f95 .f03 .hip .ispc


  CMake Error at crypto/CMakeLists.txt:378 (add_library):
    No SOURCES given to target: ton_block


  CMake Generate step failed.  Build files cannot be regenerated correctly.
  thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cmake-0.1.50/src/lib.rs:1098:5:

  command did not execute successfully, got: exit status: 1

  build script failed, must exit now
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
</details>

Turns out that there are two issues:
1. `aarch64` is not supported by `tonlibjson-sys/build.rs`
2.  [`cmake::Config::use_cxx11()`](https://docs.rs/cmake/latest/cmake/struct.Config.html#method.uses_cxx11) breaks code generation somehow, I didn't dig too deep, so it's still an open question for me. I removed it and it works 🤔

Here is a small fix for the build script to make it compile to native arch. It uses the same approach as in [build-macos-portable.rs](https://github.com/ton-blockchain/ton/blob/4cfe1d1a96acf956e28e2bbc696a143489e23631/assembly/native/build-macos-portable.sh#L127-L149) except for couple of unnecessary(?) dependencies.
Hope it helps!